### PR TITLE
Introduced visitor-based helpers to replace deprecated findFirstObjec…

### DIFF
--- a/coms/src/oms/SingleImageChain.cpp
+++ b/coms/src/oms/SingleImageChain.cpp
@@ -20,11 +20,70 @@
 #include <ossim/imaging/ossimImageHandler.h>
 #include <ossim/imaging/ossimGeoPolyCutter.h>
 #include <ossim/imaging/ossimFilterResampler.h>
+#include <ossim/base/ossimVisitor.h>
 #include <ossim/projection/ossimProjection.h>
 #include <ossim/base/ossimDatum.h>
 #include <ossim/base/ossimPropertyEvent.h>
 #include <ossim/base/ossimRefreshEvent.h>
 #include <ossim/base/ossimMultiResLevelHistogram.h>
+
+namespace
+{
+   ossimConnectableObject* findFirstByClassName(ossimImageChain* chain,
+                                               const ossimString& className,
+                                               bool recurse)
+   {
+      if (!chain)
+      {
+         return 0;
+      }
+
+      if (!recurse)
+      {
+         const ossimImageChain::ConnectableObjectList& list = chain->imageChainList();
+         for (ossim_uint32 idx = 0; idx < list.size(); ++idx)
+         {
+            const ossimRefPtr<ossimConnectableObject>& child = list[idx];
+            if (child.valid() && child->canCastTo(className))
+            {
+               return const_cast<ossimConnectableObject*>(child.get());
+            }
+         }
+         return 0;
+      }
+
+      int visitorFlags = ossimVisitor::VISIT_INPUTS | ossimVisitor::VISIT_CHILDREN;
+      ossimTypeNameVisitor visitor(className, true, visitorFlags);
+      chain->accept(visitor);
+      ossimCollectionVisitor::ListRef& objects = visitor.getObjects();
+      if (objects.empty())
+      {
+         return 0;
+      }
+      return PTR_CAST(ossimConnectableObject, objects.front().get());
+   }
+
+   ossimConnectableObject* findFirstInputByName(ossimConnectableObject* node,
+                                               const ossimString& className)
+   {
+      if (!node)
+      {
+         return 0;
+      }
+
+      const ossimConnectableObject::ConnectableObjectList& inputs = node->getInputList();
+      for (ossim_uint32 idx = 0; idx < inputs.size(); ++idx)
+      {
+         ossimConnectableObject* input = const_cast<ossimConnectableObject*>(inputs[idx].get());
+         if (input && input->canCastTo(className))
+         {
+            return input;
+         }
+      }
+
+      return 0;
+   }
+}
 
 class oms::SingleImageChain::EventListener : public ossimConnectableObjectListener
 {
@@ -227,7 +286,7 @@ void oms::SingleImageChain::setPropertyGivenClassName(const std::string& classNa
                                                       const std::string& propertyName,
                                                       const std::string& propertyValue)
 {
-   ossimConnectableObject* obj = theImageChain->findFirstObjectOfType(className);
+   ossimConnectableObject* obj = findFirstByClassName(theImageChain.get(), className, true);
    if(obj)
    {
       ((ossimPropertyInterface*)obj)->setProperty(propertyName, propertyValue);
@@ -236,7 +295,7 @@ void oms::SingleImageChain::setPropertyGivenClassName(const std::string& classNa
 
 ossimConnectableObject* oms::SingleImageChain::getConnectableObject(const std::string& className)
 {
-   return  theImageChain->findFirstObjectOfType(className);
+   return findFirstByClassName(theImageChain.get(), className, true);
 }
 
 void oms::SingleImageChain::setToSingleBand(ossim_int32 band)
@@ -295,7 +354,10 @@ void oms::SingleImageChain::setToThreeBandsReverse()
 
 void oms::SingleImageChain::setupSurfaceNormalCalculations()
 {
-   ossimRefPtr<ossimConnectableObject> surfaceNormals = theImageChain->findFirstObjectOfType("ossimImageToPlaneNormalFilter");
+   ossimConnectableObject* rawNormals = findFirstByClassName(theImageChain.get(),
+                                                            ossimString("ossimImageToPlaneNormalFilter"),
+                                                            true);
+   ossimRefPtr<ossimConnectableObject> surfaceNormals = rawNormals;
    if(!surfaceNormals)
    {
       surfaceNormals = ossimImageSourceFactoryRegistry::instance()->createImageSource(ossimString("ossimImageToPlaneNormalFilter"));
@@ -401,7 +463,9 @@ void oms::SingleImageChain::setHistogramFileToDefaultAndMode(const std::string& 
 {
    if(theBandSelector)
    {
-      ossimImageHandler* handler = (ossimImageHandler*)(theBandSelector->findInputObjectOfType("ossimImageHandler"));
+      ossimConnectableObject* handlerObj = findFirstInputByName(theBandSelector,
+                                                               ossimString("ossimImageHandler"));
+      ossimImageHandler* handler = PTR_CAST(ossimImageHandler, handlerObj);
       if(handler)
       {
          ossimFilename histoFile = handler->createDefaultHistogramFilename();

--- a/coms/src/oms/TileCacheSupport.cpp
+++ b/coms/src/oms/TileCacheSupport.cpp
@@ -332,7 +332,7 @@ namespace oms{
 
       if(m_privateData->m_entries[entry].valid())
       {
-         m_privateData->m_entries[entry]->m_outputScalarType;
+         result = m_privateData->m_entries[entry]->m_outputScalarType;
       }
 
       return result;

--- a/joms/swig/DataManager.cpp
+++ b/joms/swig/DataManager.cpp
@@ -29,9 +29,43 @@
 #include <ossim/imaging/ossimHistogramEqualization.h>
 #include <ossim/imaging/ossimVpfTileSource.h>
 #include <ossim/base/ossimProcessListener.h>
+#include <ossim/base/ossimVisitor.h>
 
 
 RTTI_DEF2(DataManager, "DataManager", ossimObject, ossimListenerManager);
+
+namespace
+{
+   ossimConnectableObject* findFirstByName(ossimImageChain* chain,
+                                           const ossimString& className,
+                                           bool recurse)
+   {
+      if (!chain)
+      {
+         return 0;
+      }
+
+      if (!recurse)
+      {
+         const ossimImageChain::ConnectableObjectList& list = chain->imageChainList();
+         for (ossim_uint32 idx = 0; idx < list.size(); ++idx)
+         {
+            const ossimRefPtr<ossimConnectableObject>& child = list[idx];
+            if (child.valid() && child->canCastTo(className))
+            {
+               return child.get();
+            }
+         }
+         return 0;
+      }
+
+      int visitorFlags = ossimVisitor::VISIT_INPUTS | ossimVisitor::VISIT_CHILDREN;
+      ossimTypeNameVisitor visitor(className, true, visitorFlags);
+      chain->accept(visitor);
+      ossimTypeNameVisitor::Collection& objects = visitor.getObjects();
+      return objects.empty() ? 0 : objects.front().get();
+   }
+}
 
 class DataManagerPrivateListener : public ossimConnectableObjectListener,
    public ossimProcessListener
@@ -690,32 +724,33 @@ ossimConnectableObject* DataManager::createStandardOrthoMosaic(const std::vector
    {
      ossimImageChain* chain = PTR_CAST(ossimImageChain, inputs[idx]);
      if(chain)
-       {
-	 ossimConnectableObject* renderer = chain->findFirstObjectOfType("ossimImageRenderer",
-									 false);
-	 if(renderer)
-	   {
-	     
-	     ossimConnectableObject* image = chain->findFirstObjectOfType("ossimImageHandler",
-									  false);
-	     if(image)
-	       {
-		 ossimImageChain* newChain = new ossimImageChain;
-		 ossimConnectableObject* dupIh = (ossimConnectableObject*)image->dup();
-		 newChain->addChild(dupIh);
-		 ossimString description = chain->getDescription();
-		 description = description.replaceAllThatMatch("[a-zA-Z]*:",
-							       "Ortho chain:");
-		 newChain->setDescription(description);
-		 add(newChain);
-		 inputList.push_back(newChain);
-	       }
-	   }
-	 else
-	   {
-	     inputList.push_back(chain);
-	   }
-       }
+     {
+        ossimConnectableObject* renderer = findFirstByName(chain,
+                                                           ossimString("ossimImageRenderer"),
+                                                           false);
+        if(renderer)
+        {
+           ossimConnectableObject* image = findFirstByName(chain,
+                                                           ossimString("ossimImageHandler"),
+                                                           false);
+           if(image)
+           {
+              ossimImageChain* newChain = new ossimImageChain;
+              ossimConnectableObject* dupIh = static_cast<ossimConnectableObject*>(image->dup());
+              newChain->addChild(dupIh);
+              ossimString description = chain->getDescription();
+              description = description.replaceAllThatMatch("[a-zA-Z]*:",
+                                                            "Ortho chain:");
+              newChain->setDescription(description);
+              add(newChain);
+              inputList.push_back(newChain);
+           }
+        }
+        else
+        {
+           inputList.push_back(chain);
+        }
+     }
    }
    if(!inputList.size())
      {
@@ -1571,4 +1606,3 @@ bool DataManager::shapeFilesOnTop() const
    }
    return result;
 }
-


### PR DESCRIPTION
…tOfType searches across both the native and SWIG layers, keeping chain lookups working without triggering compiler diagnostics (ossim-oms/coms/src/oms/SingleImageChain.cpp:30, ossim-oms/joms/swig/DataManager.cpp:37). Fixed the tile cache accessor to actually return the stored scalar type instead of discarding it (ossim-oms/coms/src/oms/TileCacheSupport.cpp:329) and checked in a Gradle build workspace under joms/.gradle/